### PR TITLE
Route /api/pendingtransactions to wallet-service

### DIFF
--- a/sourceyaml/siccar-ingress.yaml
+++ b/sourceyaml/siccar-ingress.yaml
@@ -58,6 +58,13 @@ spec:
                 name: wallet-service
                 port:
                   number: 80
+          - path: /api/pendingtransactions
+            pathType: Exact  
+            backend:
+              service:
+                name: wallet-service
+                port:
+                  number: 80
           - path: /api/registers
             pathType: Exact 
             backend:


### PR DESCRIPTION
Added missing /api/pendingtransactions routing rule to ingress